### PR TITLE
content in the first place

### DIFF
--- a/.stlintrc
+++ b/.stlintrc
@@ -12,6 +12,10 @@
       "startGroupChecking": 6,
       "order": [
         [
+          "content"
+        ],
+
+        [
           "absolute",
           "fixed",
           "position",
@@ -23,7 +27,6 @@
         ],
 
         [
-          "content",
           "display",
 
           "flexbox",


### PR DESCRIPTION
Правило `content` логично иметь на самом первом месте!

Это правило актуально преимущественно для псевдоэлементов, и это первое что нужно написать, чтоб вообще псевдоэлемент появился.

Сравните

```
.block::after
  position absolute
  content ""
```
и
```
.block::after
  content ""
  position absolute
```

Все правила, которые написаны выше `content` не будут иметь никакого значения, если правила `content` не будет вовсе, поэтому логично при разработке мы сперва пишем `content`, потом всё остальное, и не логично когда автосортировка потом ставит `content` после правил позиционирования.

Сама идея не нова, это используется уже несколько лет в некоторых публичных конфигах по сортировке правил css.