### PR TITLE
Исправление сортировки флекс-свойств

### DIFF
--- a/.stlintrc
+++ b/.stlintrc
@@ -30,19 +30,21 @@
           "display",
 
           "flexbox",
+
+          "flex-flow",
+          "flex-direction",
+          "flex-wrap",
+          "justify-content",
+          "align-content",
+          "align-items",
+          "align-self",
           "flex",
           "flex-grow",
           "flex-shrink",
           "flex-basis",
-          "flex-direction",
           "order",
+
           "flex-order",
-          "flex-wrap",
-          "flex-flow",
-          "justify-content",
-          "align-self",
-          "align-items",
-          "align-content",
           "flex-pack",
           "flex-align",
 

--- a/.stlintrc
+++ b/.stlintrc
@@ -37,6 +37,7 @@
           "justify-content",
           "align-content",
           "align-items",
+
           "align-self",
           "flex",
           "flex-grow",


### PR DESCRIPTION
1. `flex-flow` → `flex-direction` → `flex-wrap`
всё логично,  `flex-flow` — это шортхенд для `flex-direction`и `flex-wrap`

2. `justify-content`, `align-content`, `align-items` →  `align-self`, `flex` и прочее
в начале правила, влияют на флекс-айтемы (дочерние для селектора ноды), 
дальше `align-self`, `flex` же и прочее — правила, которые влияют непосредственно на сам селектор.

3. также отбил легаси-миксины пробелами